### PR TITLE
flutter_lints versions downgrade

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     path: ..
   flutter:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
   path: ^1.9.1
   path_provider: ^2.1.5
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
 dev_dependencies:
   # Provides a set of recommended lints for Flutter apps, packages, and plugins.
   build_runner: ^2.6.0
-  flutter_lints: ^6.0.0
+  flutter_lints: ^4.0.0
   # The Flutter testing framework.
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This pull request downgrades the `flutter_lints` dependency in both the main project and its example project to ensure compatibility with other dependencies.

Dependency adjustments:

* Updated `flutter_lints` in `example/pubspec.yaml` from `^6.0.0` to `^4.0.0` for compatibility purposes.
* Updated `flutter_lints` in `pubspec.yaml` from `^6.0.0` to `^4.0.0` for compatibility purposes.